### PR TITLE
Add network bug note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,9 @@ To learn more about React Native, take a look at the following resources:
 - [Learn the Basics](https://reactnative.dev/docs/getting-started) - a **guided tour** of the React Native **basics**.
 - [Blog](https://reactnative.dev/blog) - read the latest official React Native **Blog** posts.
 - [`@facebook/react-native`](https://github.com/facebook/react-native) - the Open Source; GitHub **repository** for React Native.
+
+## Problème connu : échec des requêtes réseau après un rechargement
+
+Lors de la première installation et ouverture de l'application, les appels HTTP et HTTPS fonctionnent normalement.
+Après avoir rechargé l'application (par exemple en utilisant l'option *Reload* du menu développeur), toutes les requêtes réseau retournent l'erreur `Network request failed`.
+La réinstallation de l'application rétablit temporairement le fonctionnement, mais le problème revient au prochain rechargement.


### PR DESCRIPTION
## Summary
- document a known issue where network requests fail after reloading the app

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841b004387c8328a57883713d9dea6c

## Résumé par Sourcery

Documentation :
- Ajout d’une section « Problème connu » détaillant l’erreur d’échec de requête réseau après le rechargement de l’application et sa solution de contournement temporaire.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add a ‘Known Issue’ section detailing the network request failure error after app reload and its temporary workaround

</details>